### PR TITLE
feat(bd):Tablas criterios predefinidos y atributos adicionales en tabla entregable

### DIFF
--- a/database/create_table_script.sql
+++ b/database/create_table_script.sql
@@ -1023,6 +1023,9 @@ CREATE TABLE IF NOT EXISTS entregable
     fecha_fin                  TIMESTAMP WITH TIME ZONE NOT NULL,
     estado                     enum_estado_actividad    NOT NULL DEFAULT 'no_iniciado',
     es_evaluable               BOOLEAN                  NOT NULL DEFAULT FALSE,
+	maximo_documentos          INTEGER                  NOT NULL,
+	extensiones_permitidas     TEXT                     NOT NULL,
+	peso_maximo_documento      INTEGER                  NOT NULL,
     activo                     BOOLEAN                  NOT NULL DEFAULT TRUE,
     fecha_creacion             TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     fecha_modificacion         TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1289,6 +1292,30 @@ ALTER TABLE carrera_parametro_configuracion
         FOREIGN KEY (etapa_formativa_id)
             REFERENCES etapa_formativa (etapa_formativa_id)
             ON DELETE RESTRICT; -->**REVISAR**<--
+
+-- TABLAS PARA CRITERIOS DE ENTREGABLES Y EXPOSICIONES PREDEFINIDOS
+
+CREATE TABLE IF NOT EXISTS criterio_entregable_preset
+(
+    criterio_entregable_preset_id SERIAL PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    nota_maxima DECIMAL(6,2),
+    descripcion TEXT,
+    activo BOOLEAN NOT NULL DEFAULT TRUE,
+    fecha_creacion TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    fecha_modificacion  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS criterio_exposicion_preset
+(
+    criterio_exposicion_preset_id SERIAL PRIMARY KEY,
+    nombre TEXT NOT NULL,
+    descripcion TEXT,
+	nota_maxima NUMERIC(6, 2) NOT NULL,
+    activo BOOLEAN NOT NULL DEFAULT TRUE,
+    fecha_creacion TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    fecha_modificacion  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 
 -- NECESARIO PARA QUE NO EXISTAN PROBLEMAS CON LOS ENUMS
 -- AGREGAR EL CAST PARA LOS DEMAS ENUMS DE SER NECESARIO

--- a/database/functions/functions_entregables_expos.sql
+++ b/database/functions/functions_entregables_expos.sql
@@ -7,7 +7,10 @@ RETURNS TABLE (
     fecha_inicio TIMESTAMP WITH TIME ZONE,
     fecha_fin TIMESTAMP WITH TIME ZONE,
     estado enum_estado_actividad,
-    es_evaluable BOOLEAN
+    es_evaluable BOOLEAN,
+    maximo_documentos INTEGER,
+    extensiones_permitidas TEXT,
+    peso_maximo_documento INTEGER
 ) AS $$
 BEGIN
     RETURN QUERY
@@ -18,10 +21,14 @@ BEGIN
         e.descripcion,
         e.fecha_inicio,
         e.fecha_fin,
-        e.estado AS estado,
-        e.es_evaluable
+        e.estado,
+        e.es_evaluable,
+        e.maximo_documentos,
+        e.extensiones_permitidas,
+        e.peso_maximo_documento
     FROM entregable e
-    INNER JOIN etapa_formativa_x_ciclo efc ON e.etapa_formativa_x_ciclo_id = efc.etapa_formativa_x_ciclo_id
+    INNER JOIN etapa_formativa_x_ciclo efc 
+        ON e.etapa_formativa_x_ciclo_id = efc.etapa_formativa_x_ciclo_id
     WHERE efc.etapa_formativa_x_ciclo_id = etapaFormativaXCicloId
       AND e.activo = TRUE;
 END;

--- a/database/initialization_inserts.sql
+++ b/database/initialization_inserts.sql
@@ -280,26 +280,58 @@ INSERT INTO etapa_formativa_x_ciclo (etapa_formativa_id,
 
 -- Entregables
 
-INSERT INTO entregable (etapa_formativa_x_ciclo_id,
-                        nombre,
-                        descripcion,
-                        fecha_inicio,
-                        fecha_fin,
-                        es_evaluable,
-                        activo,
-                        fecha_creacion,
-                        fecha_modificacion)
-    VALUES (1, 'Estado del arte', 'Estado del arte del tema', '2025-04-01', '2025-04-10', TRUE, TRUE, NOW(), NOW()),
-           (1, 'Entregable 1', 'Entregable 1 del tema', '2025-05-10', '2025-05-16', TRUE, TRUE, NOW(), NOW());
-
-INSERT INTO criterio_entregable (entregable_id,
-                                 nombre,
-                                 nota_maxima,
-                                 descripcion,
-                                 activo,
-                                 fecha_creacion,
-                                 fecha_modificacion)
-    VALUES (1, 'Redaccion', 5, 'Redaccion del documento', TRUE, NOW(), NOW());
+INSERT INTO entregable (
+    etapa_formativa_x_ciclo_id,
+    nombre,
+    descripcion,
+    fecha_inicio,
+    fecha_fin,
+    estado,
+    es_evaluable,
+    maximo_documentos,
+    extensiones_permitidas,
+    peso_maximo_documento,
+    activo
+) VALUES 
+(
+    1,
+    'Informe de avance 1',
+    'Primer entregable con criterios básicos.',
+    '2025-05-10 08:00:00+00',
+    '2025-05-20 23:59:00+00',
+    'no_iniciado',
+    TRUE,
+    3,
+    'pdf,docx',
+    10,
+    TRUE
+),
+(
+    1,
+    'Presentación final',
+    'Entrega de presentación en PowerPoint o PDF.',
+    '2025-06-01 08:00:00+00',
+    '2025-06-15 23:59:00+00',
+    'no_iniciado',
+    FALSE,
+    1,
+    'pdf,pptx',
+    15,
+    TRUE
+),
+(
+    1,
+    'Anexos del proyecto',
+    'Material adicional del proyecto: códigos, gráficos, etc.',
+    '2025-05-15 08:00:00+00',
+    '2025-05-30 23:59:00+00',
+    'no_iniciado',
+    TRUE,
+    5,
+    'pdf,zip,rar',
+    25,
+    TRUE
+);
 
 -- Exposiciones
 


### PR DESCRIPTION
Cambios realizados:

- Se agregaron las tablas criterio_entregable_preset y criterio_exposicion_preset para almacenar la información de criterios predefinidos. (Feedback de los JPs)

- En la tabla entregable se agregaron los atributos maximo_documentos, extensiones_permitidas y peso_maximo_documento para tener un mayor control sobre los entregables. (Feedback de los JPs)

- Debido al cambio anterior, se modificó la función listar_entregables_x_etapa_formativa_x_ciclo.

- Modificados los inserts de entregable.