### PR TITLE
Corrección funciones jurado

### DIFF
--- a/database/functions/functions_jurado.sql
+++ b/database/functions/functions_jurado.sql
@@ -235,7 +235,7 @@ inner join etapa_formativa_x_ciclo efxc
 inner join ciclo c2 
 	on c2.ciclo_id = efxc.ciclo_id 
 inner join etapa_formativa ef 
-	on ef.etapa_formativa_id = efxc.ciclo_id 
+	on ef.etapa_formativa_id = efxc.etapa_formativa_id
 inner join carrera c 
 	on c.carrera_id = ef.carrera_id 
 inner join usuario_carrera uc 
@@ -247,14 +247,15 @@ where u.usuario_id = p_coordinador_id;
 END;
 $$ LANGUAGE plpgsql STABLE;
 
-CREATE OR REPLACE FUNCTION sgtadb.listar_exposiciones_por_coordinador_v2(p_coordinador_id integer)
+
+CREATE OR REPLACE FUNCTION listar_exposiciones_por_coordinador_v2(p_coordinador_id integer)
  RETURNS TABLE(exposicion_id integer, nombre text, descripcion text, etapa_formativa_id integer, etapa_formativa_nombre text, ciclo_id integer, ciclo_nombre text, estado_planificacion_id integer, estado_planificacion_nombre text)
  LANGUAGE plpgsql
  STABLE
 AS $function$
 BEGIN
 return query
-select 
+select
     e.exposicion_id,
     e.nombre::TEXT,
     e.descripcion::TEXT,
@@ -265,25 +266,25 @@ select
     e.estado_planificacion_id,
     ep.nombre::TEXT AS estado_planificacion_nombre
 from exposicion e
-inner join estado_planificacion ep 
-	on ep.estado_planificacion_id = e.estado_planificacion_id 
+inner join estado_planificacion ep
+	on ep.estado_planificacion_id = e.estado_planificacion_id
 	and ep.nombre <> 'Sin planificar'
-inner join etapa_formativa_x_ciclo efxc 
-	on efxc.etapa_formativa_x_ciclo_id = e.etapa_formativa_x_ciclo_id 
-inner join ciclo c2 
-	on c2.ciclo_id = efxc.ciclo_id 
-inner join etapa_formativa ef 
-	on ef.etapa_formativa_id = efxc.ciclo_id 
-inner join carrera c 
-	on c.carrera_id = ef.carrera_id 
-inner join usuario_carrera uc 
+inner join etapa_formativa_x_ciclo efxc
+	on efxc.etapa_formativa_x_ciclo_id = e.etapa_formativa_x_ciclo_id
+inner join ciclo c2
+	on c2.ciclo_id = efxc.ciclo_id
+inner join etapa_formativa ef
+	on ef.etapa_formativa_id = efxc.etapa_formativa_id
+inner join carrera c
+	on c.carrera_id = ef.carrera_id
+inner join usuario_carrera uc
 	on uc.carrera_id = c.carrera_id
 	and uc.es_coordinador = true
 inner join usuario u
-	on u.usuario_id = uc.usuario_id 
+	on u.usuario_id = uc.usuario_id
 where u.usuario_id = p_coordinador_id;
 END;
-$$ LANGUAGE plpgsql STABLE;
+$function$;
 
 
 
@@ -492,11 +493,9 @@ BEGIN
         on c.carrera_id = ef.carrera_id 
     inner join usuario_carrera uc 
         on uc.carrera_id = c.carrera_id
+        and uc.es_coordinador = true
     inner join usuario u 
-        on u.usuario_id = uc.usuario_id 
-    inner join tipo_usuario tu 
-        on tu.tipo_usuario_id = u.tipo_usuario_id 
-        and tu.nombre = 'coordinador'
+        on u.usuario_id = uc.usuario_id
     WHERE ef.activo = true
         and u.usuario_id = p_coordinador_id;
 END;


### PR DESCRIPTION
Corrige cruzamiento de etapa formativa id, condición de coordinador y sintaxis de una función ya que no era correcta: no debía terminar en $$ y causaba error de coherencia? por duplicación de LANGUAGE plpgsql STABLE