### PR TITLE
fix: se quito el /api

### DIFF
--- a/apps/sgta-frontend/features/reportes/services/report-services.ts
+++ b/apps/sgta-frontend/features/reportes/services/report-services.ts
@@ -90,7 +90,7 @@ export const getEntregablesConCriterios = async (usuarioId: number): Promise<Ent
 export const obtenerEntregablesConRetraso = async (): Promise<OverdueSummary> => {
   try {
     const { idToken } = useAuthStore.getState();
-    const response = await axiosInstance.get<OverdueSummary>("/api/notifications/overdue-summary", {
+    const response = await axiosInstance.get<OverdueSummary>("/notifications/overdue-summary", {
       headers: {
         Authorization: `Bearer ${idToken}`,
       },


### PR DESCRIPTION
This pull request includes a minor update to the `apps/sgta-frontend/features/reportes/services/report-services.ts` file. The change modifies the endpoint URL in the `obtenerEntregablesConRetraso` function to remove the `/api` prefix, simplifying the path used for the API request.