### PR TITLE
Fecha límite revisión de exposiciones

### DIFF
--- a/database/create_table_script.sql
+++ b/database/create_table_script.sql
@@ -849,6 +849,7 @@ CREATE TABLE IF NOT EXISTS exposicion_x_tema (
     link_grabacion TEXT,
     estado_exposicion enum_estado_exposicion NOT NULL DEFAULT 'sin_programar', --enum_estado_exposicion | VARCHAR(255)
     nota_final NUMERIC(6, 2),
+    fecha_limite_revision DATE,
     activo BOOLEAN NOT NULL DEFAULT TRUE,
     fecha_creacion TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     fecha_modificacion TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/database/initialization/general_structure.sql
+++ b/database/initialization/general_structure.sql
@@ -222,5 +222,6 @@ INSERT INTO parametro_configuracion (nombre,
            ('Tiempo Limite Jurado','Tiempo limite para que jurado revise entregables',1, 'integer'),
            ('Peso Asesor','Peso asignado a la calificación del asesor en situaciones de evaluación que involucran la participación del jurado',1, 'integer'),
            ('Limite Propuestas Alumno', 'Define el límite en cantidad de propuestas de tema de un estudiante', 1, 'integer'),
-           ('Limite Postulaciones Alumno', 'Define el límite de postulaciones a temas libres que puede realizar un estudiante', 1, 'integer');
+           ('Limite Postulaciones Alumno', 'Define el límite de postulaciones a temas libres que puede realizar un estudiante', 1, 'integer'),
+           ('Tiempo Limite Jurado Expo', 'Tiempo limite para que jurado revise las exposiciones',1, 'integer');
 

--- a/database/initialization/ing_1_informatica_structure.sql
+++ b/database/initialization/ing_1_informatica_structure.sql
@@ -93,7 +93,8 @@ SELECT 1 as carrera_id,
                           ('Tiempo Limite Jurado', '15'),
                           ('Peso Asesor', '20'),
                           ('Limite Propuestas Alumno', '2'),
-                          ('Limite Postulaciones Alumno', '2'))
+                          ('Limite Postulaciones Alumno', '2'),
+                          ('Tiempo Limite Jurado Expo', '15'))
                         AS v(nombre, valor) ON p.nombre = v.nombre;
 
 


### PR DESCRIPTION
Se agregó un atributo no obligatorio a exposicion x tema que es fecha limite revision, así como un parámetro de configuración para que así como hay límite de revisión de entregable, también lo haya para exposición.