### PR TITLE
Reportes: Filtros por etapa formativa

### DIFF
--- a/apps/sgta-frontend/features/reportes/types/coordinator-reports.type.ts
+++ b/apps/sgta-frontend/features/reportes/types/coordinator-reports.type.ts
@@ -18,6 +18,8 @@ export interface JurorDistribution {
   teacherName: string;
   count: number;
   areaName: string;
+  areasConocimiento: string[];
+  etapasFormativasCount: Record<string, number>;
 }
 
 export interface AdvisorPerformance {
@@ -25,6 +27,7 @@ export interface AdvisorPerformance {
   areaName: string;
   performancePercentage: number;
   totalStudents: number;
+  etapasFormativasCount: Record<string, number>;
 }
 
 export interface TopicTrend {


### PR DESCRIPTION
This pull request introduces updates to the `coordinator-reports.type.ts` file, adding new fields to several interfaces to enhance data representation for coordinator reports. These changes primarily focus on incorporating `etapasFormativasCount` and `areasConocimiento` fields for better granularity and categorization.

### Enhancements to data representation:

* Added a new `etapasFormativasCount` field (of type `Record<string, number>`) to the `TopicArea`, `AdvisorDistribution`, `JurorDistribution`, `AdvisorPerformance`, and `TopicTrend` interfaces to track counts by formative stages.
* Added a new `areasConocimiento` field (of type `string[]`) to the `AdvisorDistribution` and `JurorDistribution` interfaces to list areas of knowledge associated with advisors and jurors.