### PR TITLE
feat: agregar función para obtener todos los ciclos activos o no

### DIFF
--- a/apps/sgta-frontend/features/configuracion/services/etapa-formativa-ciclo.ts
+++ b/apps/sgta-frontend/features/configuracion/services/etapa-formativa-ciclo.ts
@@ -1,6 +1,6 @@
+import { useAuthStore } from "@/features/auth/store/auth-store";
 import axiosInstance from "@/lib/axios/axios-instance";
 import { EtapaFormativaCiclo, EtapaFormativaCicloCreate } from "../types/etapa-formativa-ciclo";
-import { useAuthStore } from "@/features/auth/store/auth-store";
 
 export interface EtapaFormativaXCicloTesista {
     id: number;
@@ -62,6 +62,12 @@ export const ciclosService = {
     getAll: async () => {
         const response = await axiosInstance.get("/ciclos/listarCiclos");
         return response.data;
+    },
+
+    getAllYears: async () => {
+        const response = await axiosInstance.get("/ciclos/listarTodosLosCiclos");
+        return response.data;
     }
 };
+
 

--- a/apps/sgta-frontend/features/reportes/views/coordinator-reports.tsx
+++ b/apps/sgta-frontend/features/reportes/views/coordinator-reports.tsx
@@ -295,13 +295,11 @@ export function CoordinatorReports() {
     const fetchCiclos = async () => {
       try {
         setLoadingCiclos(true);
-        const data = await ciclosService.getAll();
-        // Filtrar solo los ciclos activos
-        const ciclosActivos = data.filter((ciclo: {activo: boolean}) => ciclo.activo === true);
-        setCiclos(ciclosActivos);
+        const data = await ciclosService.getAllYears();
+        setCiclos(data);
         // Si no hay año/semestre seleccionado y hay ciclos disponibles, seleccionar el primero
-        if (!selectedYear && !selectedSemester && ciclosActivos.length > 0) {
-          const primerCiclo = ciclosActivos[0];
+        if (!selectedYear && !selectedSemester && data.length > 0) {
+          const primerCiclo = data[0];
           setSelectedYear(primerCiclo.anio.toString());
           setSelectedSemester(primerCiclo.semestre);
         }


### PR DESCRIPTION
This pull request introduces changes to the `etapa-formativa-ciclo` service and the `CoordinatorReports` view to enhance functionality and simplify code. The most notable updates include adding a new service method to fetch all cycles, modifying the `CoordinatorReports` component to use this new method, and cleaning up imports.

### Service Updates:
* [`apps/sgta-frontend/features/configuracion/services/etapa-formativa-ciclo.ts`](diffhunk://#diff-3115a044c478dd691c8fe28ca96fd167090de808bd706ab6431c77d895453ca0R65-R73): Added a new method `getAllYears` to the `ciclosService` object to fetch all cycles (`listarTodosLosCiclos` endpoint).

### View Updates:
* [`apps/sgta-frontend/features/reportes/views/coordinator-reports.tsx`](diffhunk://#diff-8518403deedca530f8ad94a529e275d58476789f9d8f8b61eadb3e9cb0069388L298-R302): Updated the `fetchCiclos` function in the `CoordinatorReports` component to use the new `getAllYears` service method instead of `getAll`. Removed filtering for active cycles, now directly setting all fetched cycles. Simplified logic for selecting the first cycle when no year or semester is pre-selected.

### Code Cleanup:
* [`apps/sgta-frontend/features/configuracion/services/etapa-formativa-ciclo.ts`](diffhunk://#diff-3115a044c478dd691c8fe28ca96fd167090de808bd706ab6431c77d895453ca0R1-L3): Fixed import order by moving `useAuthStore` to the top for consistency.