### PR TITLE
Return modified

### DIFF
--- a/apps/sgta-backend/src/main/java/pucp/edu/pe/sgta/controller/RevisionDocumentoController.java
+++ b/apps/sgta-backend/src/main/java/pucp/edu/pe/sgta/controller/RevisionDocumentoController.java
@@ -161,8 +161,8 @@ public class RevisionDocumentoController {
             .attachment()
             .filename(filename)
             .build());
-
-        return new ResponseEntity<>(annotatedPdf, headers, HttpStatus.OK);
+        
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_PDF).header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"").body(annotatedPdf);
     }
   
     @GetMapping("/jurado")


### PR DESCRIPTION
Return modificado a 
return ResponseEntity.ok().contentType(MediaType.APPLICATION_PDF).header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"").body(annotatedPdf);
para evitar que el frontend lo detecte como JSON.